### PR TITLE
fix: Serviço de Migração do docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,11 @@ services:
     volumes:
       - db_data:/app/sqlite-data
     environment:
+      DEBUG: ${DEBUG:-True}
+      ALLOWED_HOSTS: ${ALLOWED_HOSTS:-*}
+      CORS_ALLOW_ALL_ORIGINS: ${CORS_ALLOW_ALL_ORIGINS:-True}
+      # Useful when testing via Expo Web (browser). Add LAN host:port if needed.
+      CSRF_TRUSTED_ORIGINS: ${CSRF_TRUSTED_ORIGINS:-http://localhost:19006,http://127.0.0.1:19006}
       # Default to a persistent SQLite file inside the volume-backed directory
       DATABASE_URL: ${DATABASE_URL:-sqlite:////app/sqlite-data/db.sqlite3}
       CONN_MAX_AGE: ${CONN_MAX_AGE:-0}
@@ -21,13 +26,18 @@ services:
     build:
       context: .
     image: ezgestor-app:latest
-    command: ["python", "manage.py", "migrate"]
+    command: ["sh", "-c", "python manage.py makemigrations --noinput && python manage.py migrate --noinput"]
     environment:
+      DEBUG: ${DEBUG:-True}
+      ALLOWED_HOSTS: ${ALLOWED_HOSTS:-*}
+      CORS_ALLOW_ALL_ORIGINS: ${CORS_ALLOW_ALL_ORIGINS:-True}
+      CSRF_TRUSTED_ORIGINS: ${CSRF_TRUSTED_ORIGINS:-http://localhost:19006,http://127.0.0.1:19006}
       # Match the web default so migrations hit the same DB by default
       DATABASE_URL: ${DATABASE_URL:-sqlite:////app/sqlite-data/db.sqlite3}
       CONN_MAX_AGE: ${CONN_MAX_AGE:-0}
     volumes:
       - db_data:/app/sqlite-data
+      - ./backend:/app
     restart: "no"
 
   cloudsql-proxy:


### PR DESCRIPTION
This pull request updates the `docker-compose.yml` configuration to improve environment variable management and streamline database migrations for both the main web service and the migration service. The changes make it easier to configure the backend for local development and testing, and ensure migrations are handled more robustly.

**Environment variable improvements:**

* Added environment variables for `DEBUG`, `ALLOWED_HOSTS`, `CORS_ALLOW_ALL_ORIGINS`, and `CSRF_TRUSTED_ORIGINS` to both the main web service and the migration service, making backend configuration more flexible and development-friendly. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R16-R20) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L24-R40)

**Database migration process:**

* Updated the migration service command to run `makemigrations` before `migrate`, ensuring all model changes are applied automatically during container startup.

**Development workflow enhancements:**

* Mounted the local `./backend` directory into the migration service container, allowing changes to backend code to be reflected immediately during development and migration runs.