### PR TITLE
fix: ensure mysqlclient is specified in requirements.txt

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,3 +8,4 @@ whitenoise==6.7.0
 gunicorn==23.0.0
 dj-database-url==2.2.0
 djangorestframework_simplejwt==5.5.1
+mysqlclient==2.2.4


### PR DESCRIPTION
This pull request adds a new dependency to the backend requirements, specifically the `mysqlclient` package. This package is necessary for connecting Django to a MySQL database. 

- Dependency management:
  * Added `mysqlclient==2.2.4` to `backend/requirements.txt` to enable MySQL database support.