### PR TITLE
Fix: Remove footer duplicado na dashboard

### DIFF
--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -121,8 +121,7 @@ function DashboardPage() {
         onClose={() => setIsModalOpen(false)}
         onSaleAdded={handleSaleAdded}
       />
-      
-      <Footer />
+
     </div>
   );
 }


### PR DESCRIPTION
This pull request makes a small change to the `DashboardPage` component by removing the duplicate `Footer` component from the rendered output.