### PR TITLE
Feature: Implementação de gráfico de fluxo de caixa (Backend, frontend e mobile)

### DIFF
--- a/backend/financeiro/fixtures/seed_cashflow.json
+++ b/backend/financeiro/fixtures/seed_cashflow.json
@@ -1,0 +1,655 @@
+[
+  {
+    "model": "accounts.empresa",
+    "pk": 2000,
+    "fields": {
+      "nome_fantasia": "Empresa Cashflow",
+      "razao_social": "Empresa Cashflow LTDA",
+      "cnpj": "11.222.333/0001-44",
+      "data_cadastro": "2025-01-01T00:00:00Z"
+    }
+  },
+  {
+    "model": "accounts.usuario",
+    "pk": 2000,
+    "fields": {
+      "password": "pbkdf2_sha256$720000$2GoetH4aCbEvRoz5ICkP5q$KHURKtE2zOHn7yCMVUSOSueKnRoQP6ygZcs6TAZR/bU=",
+      "last_login": null,
+      "is_superuser": false,
+      "first_name": "Teste",
+      "last_name": "Cashflow",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2025-01-01T00:00:00Z",
+      "email": "cashflow@example.com",
+      "nivel_acesso": "administrador",
+      "empresa": 2000,
+      "groups": [],
+      "user_permissions": []
+    }
+  },
+  {
+    "model": "financeiro.lancamentofinanceiro",
+    "pk": 200000,
+    "fields": {
+      "empresa": 2000,
+      "venda": null,
+      "descricao": "Entrada - Dia 1",
+      "valor": "1500.00",
+      "tipo": "entrada",
+      "data_lancamento": "2025-10-01T10:00:00Z",
+      "categoria": "Vendas"
+    }
+  },
+  {
+    "model": "financeiro.lancamentofinanceiro",
+    "pk": 200001,
+    "fields": {
+      "empresa": 2000,
+      "venda": null,
+      "descricao": "Saída - Dia 1",
+      "valor": "500.00",
+      "tipo": "saida",
+      "data_lancamento": "2025-10-01T15:00:00Z",
+      "categoria": "Despesas"
+    }
+  },
+  {
+    "model": "financeiro.lancamentofinanceiro",
+    "pk": 200002,
+    "fields": {
+      "empresa": 2000,
+      "venda": null,
+      "descricao": "Entrada - Dia 10",
+      "valor": "2000.00",
+      "tipo": "entrada",
+      "data_lancamento": "2025-10-10T11:00:00Z",
+      "categoria": "Vendas"
+    }
+  },
+  {
+    "model": "financeiro.lancamentofinanceiro",
+    "pk": 200003,
+    "fields": {
+      "empresa": 2000,
+      "venda": null,
+      "descricao": "Saída - Dia 10",
+      "valor": "700.00",
+      "tipo": "saida",
+      "data_lancamento": "2025-10-10T16:00:00Z",
+      "categoria": "Despesas"
+    }
+  },
+  {
+    "model": "financeiro.lancamentofinanceiro",
+    "pk": 200004,
+    "fields": {
+      "empresa": 2000,
+      "venda": null,
+      "descricao": "Entrada - Dia 20",
+      "valor": "1800.00",
+      "tipo": "entrada",
+      "data_lancamento": "2025-10-20T12:00:00Z",
+      "categoria": "Vendas"
+    }
+  },
+  {
+    "model": "financeiro.lancamentofinanceiro",
+    "pk": 200005,
+    "fields": {
+      "empresa": 2000,
+      "venda": null,
+      "descricao": "Saída - Dia 20",
+      "valor": "600.00",
+      "tipo": "saida",
+      "data_lancamento": "2025-10-20T18:00:00Z",
+      "categoria": "Despesas"
+    }
+  },
+  {
+    "model": "financeiro.lancamentofinanceiro",
+    "pk": 200006,
+    "fields": {
+      "empresa": 2000,
+      "venda": null,
+      "descricao": "Entrada - Jan",
+      "valor": "10000.00",
+      "tipo": "entrada",
+      "data_lancamento": "2025-01-15T09:00:00Z",
+      "categoria": "Vendas"
+    }
+  },
+  {
+    "model": "financeiro.lancamentofinanceiro",
+    "pk": 200007,
+    "fields": {
+      "empresa": 2000,
+      "venda": null,
+      "descricao": "Saída - Jan",
+      "valor": "3000.00",
+      "tipo": "saida",
+      "data_lancamento": "2025-01-20T09:00:00Z",
+      "categoria": "Despesas"
+    }
+  },
+  {
+    "model": "financeiro.lancamentofinanceiro",
+    "pk": 200008,
+    "fields": {
+      "empresa": 2000,
+      "venda": null,
+      "descricao": "Entrada - Jun",
+      "valor": "12000.00",
+      "tipo": "entrada",
+      "data_lancamento": "2025-06-10T09:00:00Z",
+      "categoria": "Vendas"
+    }
+  },
+  {
+    "model": "financeiro.lancamentofinanceiro",
+    "pk": 200009,
+    "fields": {
+      "empresa": 2000,
+      "venda": null,
+      "descricao": "Saída - Jun",
+      "valor": "4000.00",
+      "tipo": "saida",
+      "data_lancamento": "2025-06-18T09:00:00Z",
+      "categoria": "Despesas"
+    }
+  },
+  {
+    "model": "financeiro.lancamentofinanceiro",
+    "pk": 200010,
+    "fields": {
+      "empresa": 2000,
+      "venda": null,
+      "descricao": "Entrada - Dia 5",
+      "valor": "900.00",
+      "tipo": "entrada",
+      "data_lancamento": "2025-10-05T14:00:00Z",
+      "categoria": "Vendas"
+    }
+  },
+  {
+    "model": "financeiro.lancamentofinanceiro",
+    "pk": 200011,
+    "fields": {
+      "empresa": 2000,
+      "venda": null,
+      "descricao": "Saída - Dia 5",
+      "valor": "300.00",
+      "tipo": "saida",
+      "data_lancamento": "2025-10-05T17:00:00Z",
+      "categoria": "Despesas"
+    }
+  },
+  {
+    "model": "financeiro.lancamentofinanceiro",
+    "pk": 200012,
+    "fields": {
+      "empresa": 2000,
+      "venda": null,
+      "descricao": "Entrada - Dia 15",
+      "valor": "2500.00",
+      "tipo": "entrada",
+      "data_lancamento": "2025-10-15T10:00:00Z",
+      "categoria": "Vendas"
+    }
+  },
+  {
+    "model": "financeiro.lancamentofinanceiro",
+    "pk": 200013,
+    "fields": {
+      "empresa": 2000,
+      "venda": null,
+      "descricao": "Saída - Dia 15",
+      "valor": "800.00",
+      "tipo": "saida",
+      "data_lancamento": "2025-10-15T13:00:00Z",
+      "categoria": "Despesas"
+    }
+  },
+  {
+    "model": "financeiro.lancamentofinanceiro",
+    "pk": 200014,
+    "fields": {
+      "empresa": 2000,
+      "venda": null,
+      "descricao": "Entrada - Dia 19",
+      "valor": "2200.00",
+      "tipo": "entrada",
+      "data_lancamento": "2025-10-19T11:00:00Z",
+      "categoria": "Vendas"
+    }
+  },
+  {
+    "model": "financeiro.lancamentofinanceiro",
+    "pk": 200015,
+    "fields": {
+      "empresa": 2000,
+      "venda": null,
+      "descricao": "Saída - Dia 19",
+      "valor": "450.00",
+      "tipo": "saida",
+      "data_lancamento": "2025-10-19T16:00:00Z",
+      "categoria": "Despesas"
+    }
+  },
+  {
+    "model": "financeiro.lancamentofinanceiro",
+    "pk": 200016,
+    "fields": {
+      "empresa": 2000,
+      "venda": null,
+      "descricao": "Entrada - Feb",
+      "valor": "8000.00",
+      "tipo": "entrada",
+      "data_lancamento": "2025-02-12T09:00:00Z",
+      "categoria": "Vendas"
+    }
+  },
+  {
+    "model": "financeiro.lancamentofinanceiro",
+    "pk": 200017,
+    "fields": {
+      "empresa": 2000,
+      "venda": null,
+      "descricao": "Saída - Feb",
+      "valor": "2500.00",
+      "tipo": "saida",
+      "data_lancamento": "2025-02-18T09:00:00Z",
+      "categoria": "Despesas"
+    }
+  },
+  {
+    "model": "financeiro.lancamentofinanceiro",
+    "pk": 200018,
+    "fields": {
+      "empresa": 2000,
+      "venda": null,
+      "descricao": "Entrada - Apr",
+      "valor": "11000.00",
+      "tipo": "entrada",
+      "data_lancamento": "2025-04-08T09:00:00Z",
+      "categoria": "Vendas"
+    }
+  },
+  {
+    "model": "financeiro.lancamentofinanceiro",
+    "pk": 200019,
+    "fields": {
+      "empresa": 2000,
+      "venda": null,
+      "descricao": "Saída - Apr",
+      "valor": "3500.00",
+      "tipo": "saida",
+      "data_lancamento": "2025-04-22T09:00:00Z",
+      "categoria": "Despesas"
+    }
+  },
+  {
+    "model": "financeiro.lancamentofinanceiro",
+    "pk": 200020,
+    "fields": {
+      "empresa": 2000,
+      "venda": null,
+      "descricao": "Entrada - Aug",
+      "valor": "14000.00",
+      "tipo": "entrada",
+      "data_lancamento": "2025-08-05T09:00:00Z",
+      "categoria": "Vendas"
+    }
+  },
+  {
+    "model": "financeiro.lancamentofinanceiro",
+    "pk": 200021,
+    "fields": {
+      "empresa": 2000,
+      "venda": null,
+      "descricao": "Saída - Aug",
+      "valor": "5000.00",
+      "tipo": "saida",
+      "data_lancamento": "2025-08-25T09:00:00Z",
+      "categoria": "Despesas"
+    }
+  },
+  {
+    "model": "financeiro.lancamentofinanceiro",
+    "pk": 200022,
+    "fields": {
+      "empresa": 2000,
+      "venda": null,
+      "descricao": "Entrada - Oct",
+      "valor": "13000.00",
+      "tipo": "entrada",
+      "data_lancamento": "2025-10-08T09:00:00Z",
+      "categoria": "Vendas"
+    }
+  },
+  {
+    "model": "financeiro.lancamentofinanceiro",
+    "pk": 200023,
+    "fields": {
+      "empresa": 2000,
+      "venda": null,
+      "descricao": "Saída - Oct",
+      "valor": "4200.00",
+      "tipo": "saida",
+      "data_lancamento": "2025-10-12T09:00:00Z",
+      "categoria": "Despesas"
+    }
+  },
+  {
+    "model": "financeiro.lancamentofinanceiro",
+    "pk": 200024,
+    "fields": {
+      "empresa": 2000,
+      "venda": null,
+      "descricao": "Entrada - Last 7 Days (Oct 13)",
+      "valor": "1600.00",
+      "tipo": "entrada",
+      "data_lancamento": "2025-10-13T10:00:00Z",
+      "categoria": "Vendas"
+    }
+  },
+  {
+    "model": "financeiro.lancamentofinanceiro",
+    "pk": 200025,
+    "fields": {
+      "empresa": 2000,
+      "venda": null,
+      "descricao": "Saída - Last 7 Days (Oct 13)",
+      "valor": "400.00",
+      "tipo": "saida",
+      "data_lancamento": "2025-10-13T15:00:00Z",
+      "categoria": "Despesas"
+    }
+  },
+  {
+    "model": "financeiro.lancamentofinanceiro",
+    "pk": 200026,
+    "fields": {
+      "empresa": 2000,
+      "venda": null,
+      "descricao": "Entrada - Last 7 Days (Oct 16)",
+      "valor": "2100.00",
+      "tipo": "entrada",
+      "data_lancamento": "2025-10-16T11:00:00Z",
+      "categoria": "Vendas"
+    }
+  },
+  {
+    "model": "financeiro.lancamentofinanceiro",
+    "pk": 200027,
+    "fields": {
+      "empresa": 2000,
+      "venda": null,
+      "descricao": "Saída - Last 7 Days (Oct 16)",
+      "valor": "550.00",
+      "tipo": "saida",
+      "data_lancamento": "2025-10-16T14:00:00Z",
+      "categoria": "Despesas"
+    }
+  },
+  {
+    "model": "financeiro.lancamentofinanceiro",
+    "pk": 200028,
+    "fields": {
+      "empresa": 2000,
+      "venda": null,
+      "descricao": "Entrada - Last 7 Days (Oct 18)",
+      "valor": "1900.00",
+      "tipo": "entrada",
+      "data_lancamento": "2025-10-18T12:00:00Z",
+      "categoria": "Vendas"
+    }
+  },
+  {
+    "model": "financeiro.lancamentofinanceiro",
+    "pk": 200029,
+    "fields": {
+      "empresa": 2000,
+      "venda": null,
+      "descricao": "Saída - Last 7 Days (Oct 18)",
+      "valor": "650.00",
+      "tipo": "saida",
+      "data_lancamento": "2025-10-18T17:00:00Z",
+      "categoria": "Despesas"
+    }
+  },
+  {
+    "model": "financeiro.lancamentofinanceiro",
+    "pk": 200030,
+    "fields": {
+      "empresa": 2000,
+      "venda": null,
+      "descricao": "Entrada - Last 30 Days (Sep 20)",
+      "valor": "1700.00",
+      "tipo": "entrada",
+      "data_lancamento": "2025-09-20T09:00:00Z",
+      "categoria": "Vendas"
+    }
+  },
+  {
+    "model": "financeiro.lancamentofinanceiro",
+    "pk": 200031,
+    "fields": {
+      "empresa": 2000,
+      "venda": null,
+      "descricao": "Saída - Last 30 Days (Sep 20)",
+      "valor": "450.00",
+      "tipo": "saida",
+      "data_lancamento": "2025-09-20T13:00:00Z",
+      "categoria": "Despesas"
+    }
+  },
+  {
+    "model": "financeiro.lancamentofinanceiro",
+    "pk": 200032,
+    "fields": {
+      "empresa": 2000,
+      "venda": null,
+      "descricao": "Entrada - Last 30 Days (Sep 25)",
+      "valor": "2300.00",
+      "tipo": "entrada",
+      "data_lancamento": "2025-09-25T10:00:00Z",
+      "categoria": "Vendas"
+    }
+  },
+  {
+    "model": "financeiro.lancamentofinanceiro",
+    "pk": 200033,
+    "fields": {
+      "empresa": 2000,
+      "venda": null,
+      "descricao": "Saída - Last 30 Days (Sep 25)",
+      "valor": "750.00",
+      "tipo": "saida",
+      "data_lancamento": "2025-09-25T16:00:00Z",
+      "categoria": "Despesas"
+    }
+  },
+  {
+    "model": "financeiro.lancamentofinanceiro",
+    "pk": 200034,
+    "fields": {
+      "empresa": 2000,
+      "venda": null,
+      "descricao": "Entrada - Last 30 Days (Sep 28)",
+      "valor": "1400.00",
+      "tipo": "entrada",
+      "data_lancamento": "2025-09-28T11:00:00Z",
+      "categoria": "Vendas"
+    }
+  },
+  {
+    "model": "financeiro.lancamentofinanceiro",
+    "pk": 200035,
+    "fields": {
+      "empresa": 2000,
+      "venda": null,
+      "descricao": "Saída - Last 30 Days (Sep 28)",
+      "valor": "350.00",
+      "tipo": "saida",
+      "data_lancamento": "2025-09-28T14:00:00Z",
+      "categoria": "Despesas"
+    }
+  },
+  {
+    "model": "financeiro.lancamentofinanceiro",
+    "pk": 200036,
+    "fields": {
+      "empresa": 2000,
+      "venda": null,
+      "descricao": "Entrada - Last 12 Months (Nov 2024)",
+      "valor": "9000.00",
+      "tipo": "entrada",
+      "data_lancamento": "2024-11-15T09:00:00Z",
+      "categoria": "Vendas"
+    }
+  },
+  {
+    "model": "financeiro.lancamentofinanceiro",
+    "pk": 200037,
+    "fields": {
+      "empresa": 2000,
+      "venda": null,
+      "descricao": "Saída - Last 12 Months (Nov 2024)",
+      "valor": "2800.00",
+      "tipo": "saida",
+      "data_lancamento": "2024-11-20T09:00:00Z",
+      "categoria": "Despesas"
+    }
+  },
+  {
+    "model": "financeiro.lancamentofinanceiro",
+    "pk": 200038,
+    "fields": {
+      "empresa": 2000,
+      "venda": null,
+      "descricao": "Entrada - Last 12 Months (Dec 2024)",
+      "valor": "9500.00",
+      "tipo": "entrada",
+      "data_lancamento": "2024-12-10T09:00:00Z",
+      "categoria": "Vendas"
+    }
+  },
+  {
+    "model": "financeiro.lancamentofinanceiro",
+    "pk": 200039,
+    "fields": {
+      "empresa": 2000,
+      "venda": null,
+      "descricao": "Saída - Last 12 Months (Dec 2024)",
+      "valor": "3200.00",
+      "tipo": "saida",
+      "data_lancamento": "2024-12-18T09:00:00Z",
+      "categoria": "Despesas"
+    }
+  },
+  {
+    "model": "financeiro.lancamentofinanceiro",
+    "pk": 200040,
+    "fields": {
+      "empresa": 2000,
+      "venda": null,
+      "descricao": "Entrada - Last 12 Months (Mar 2025)",
+      "valor": "10500.00",
+      "tipo": "entrada",
+      "data_lancamento": "2025-03-12T09:00:00Z",
+      "categoria": "Vendas"
+    }
+  },
+  {
+    "model": "financeiro.lancamentofinanceiro",
+    "pk": 200041,
+    "fields": {
+      "empresa": 2000,
+      "venda": null,
+      "descricao": "Saída - Last 12 Months (Mar 2025)",
+      "valor": "3800.00",
+      "tipo": "saida",
+      "data_lancamento": "2025-03-22T09:00:00Z",
+      "categoria": "Despesas"
+    }
+  },
+  {
+    "model": "financeiro.lancamentofinanceiro",
+    "pk": 200042,
+    "fields": {
+      "empresa": 2000,
+      "venda": null,
+      "descricao": "Entrada - Last 12 Months (May 2025)",
+      "valor": "11500.00",
+      "tipo": "entrada",
+      "data_lancamento": "2025-05-08T09:00:00Z",
+      "categoria": "Vendas"
+    }
+  },
+  {
+    "model": "financeiro.lancamentofinanceiro",
+    "pk": 200043,
+    "fields": {
+      "empresa": 2000,
+      "venda": null,
+      "descricao": "Saída - Last 12 Months (May 2025)",
+      "valor": "4100.00",
+      "tipo": "saida",
+      "data_lancamento": "2025-05-20T09:00:00Z",
+      "categoria": "Despesas"
+    }
+  },
+  {
+    "model": "financeiro.lancamentofinanceiro",
+    "pk": 200044,
+    "fields": {
+      "empresa": 2000,
+      "venda": null,
+      "descricao": "Entrada - Last 12 Months (Jul 2025)",
+      "valor": "12500.00",
+      "tipo": "entrada",
+      "data_lancamento": "2025-07-15T09:00:00Z",
+      "categoria": "Vendas"
+    }
+  },
+  {
+    "model": "financeiro.lancamentofinanceiro",
+    "pk": 200045,
+    "fields": {
+      "empresa": 2000,
+      "venda": null,
+      "descricao": "Saída - Last 12 Months (Jul 2025)",
+      "valor": "4500.00",
+      "tipo": "saida",
+      "data_lancamento": "2025-07-25T09:00:00Z",
+      "categoria": "Despesas"
+    }
+  },
+  {
+    "model": "financeiro.lancamentofinanceiro",
+    "pk": 200046,
+    "fields": {
+      "empresa": 2000,
+      "venda": null,
+      "descricao": "Entrada - Last 12 Months (Sep 2025)",
+      "valor": "13500.00",
+      "tipo": "entrada",
+      "data_lancamento": "2025-09-10T09:00:00Z",
+      "categoria": "Vendas"
+    }
+  },
+  {
+    "model": "financeiro.lancamentofinanceiro",
+    "pk": 200047,
+    "fields": {
+      "empresa": 2000,
+      "venda": null,
+      "descricao": "Saída - Last 12 Months (Sep 2025)",
+      "valor": "4800.00",
+      "tipo": "saida",
+      "data_lancamento": "2025-09-22T09:00:00Z",
+      "categoria": "Despesas"
+    }
+  }
+]

--- a/backend/financeiro/urls.py
+++ b/backend/financeiro/urls.py
@@ -1,5 +1,5 @@
 from django.urls import path
-from .views import FinancialStatsView, LancamentoFinanceiroListView, LancamentoCategoriasView, DashboardStatsView, LancamentoFinanceiroDetailView
+from .views import FinancialStatsView, LancamentoFinanceiroListView, LancamentoCategoriasView, DashboardStatsView, LancamentoFinanceiroDetailView, CashFlowSeriesView
 
 urlpatterns = [
     path('lancamentos/', LancamentoFinanceiroListView.as_view(), name='list-lancamentos'),
@@ -7,4 +7,5 @@ urlpatterns = [
     path('stats/', FinancialStatsView.as_view(), name='financial-stats'), 
     path('dashboard/', DashboardStatsView.as_view(), name='dashboard-stats'),
     path('categorias/', LancamentoCategoriasView.as_view(), name='list-categorias-lancamentos'),
+    path('cashflow/', CashFlowSeriesView.as_view(), name='cashflow-series'),
 ]

--- a/backend/financeiro/views.py
+++ b/backend/financeiro/views.py
@@ -3,7 +3,7 @@ from .models import LancamentoFinanceiro
 from .serializers import LancamentoFinanceiroSerializer
 from rest_framework import views
 from rest_framework.response import Response
-from django.db.models import Sum, F
+from django.db.models import Sum, F, Q
 from django.db.models.functions import Coalesce
 from django.db.models import DecimalField
 from rest_framework.pagination import PageNumberPagination
@@ -11,6 +11,9 @@ from vendas.views import StandardResultsSetPagination
 from django.utils import timezone
 from vendas.models import Venda
 from estoque.models import Produto
+from django.db.models.functions import TruncDate, TruncMonth
+
+from datetime import timedelta, date
 
 class LancamentoFinanceiroListView(generics.ListCreateAPIView):
     """
@@ -185,3 +188,116 @@ class DashboardStatsView(views.APIView):
         }
 
         return Response(data)
+
+
+class CashFlowSeriesView(views.APIView):
+    """
+    Aggregated time series for inflows vs outflows for the authenticated user's empresa.
+    Query params:
+      - timeframe: '7days' | '30days' | 'currentMonth' | '12months'
+    Response shape:
+      { timeframe, start, end, data: [{ period, inflows, outflows, net }] }
+    """
+    permission_classes = [permissions.IsAuthenticated]
+
+    def get(self, request, *args, **kwargs):
+        empresa = request.user.empresa
+        timeframe = request.query_params.get('timeframe', '30days')
+
+        now = timezone.localtime()
+
+        # Determine range and bucket function
+        if timeframe == '7days':
+            end_date = now.date()
+            start_date = end_date - timedelta(days=6)
+            bucket = TruncDate('data_lancamento')
+            label_fn = lambda d: f"{d.day:02d}/{d.month:02d}"
+            periods = [start_date + timedelta(days=i) for i in range(0, 7)]
+            is_monthly = False
+        elif timeframe == 'currentMonth':
+            end_date = now.date()
+            start_date = date(now.year, now.month, 1)
+            days = (end_date - start_date).days + 1
+            bucket = TruncDate('data_lancamento')
+            label_fn = lambda d: f"{d.day:02d}/{d.month:02d}"
+            periods = [start_date + timedelta(days=i) for i in range(0, days)]
+            is_monthly = False
+        elif timeframe == '12months':
+            # Last 12 months including current
+            end_date = date(now.year, now.month, 1)
+            # start at 11 months ago first day
+            start_year = end_date.year if end_date.month > 1 else end_date.year - 1
+            start_month = ((end_date.month - 11 - 1) % 12) + 1
+            if end_date.month - 11 <= 0:
+                start_year = end_date.year - 1
+            start_date = date(start_year, start_month, 1)
+            bucket = TruncMonth('data_lancamento')
+            month_names = ['Jan', 'Fev', 'Mar', 'Abr', 'Mai', 'Jun', 'Jul', 'Ago', 'Set', 'Out', 'Nov', 'Dez']
+            def add_months(y: int, m: int, add: int):
+                total = (y * 12 + (m - 1)) + add
+                ny = total // 12
+                nm = (total % 12) + 1
+                return ny, nm
+            periods = []
+            for i in range(12):
+                y, m = add_months(start_date.year, start_date.month, i)
+                periods.append(date(y, m, 1))
+            label_fn = lambda d: f"{month_names[d.month-1]}/{str(d.year)[-2:]}"
+            is_monthly = True
+        else:  # default to 30days
+            end_date = now.date()
+            start_date = end_date - timedelta(days=29)
+            bucket = TruncDate('data_lancamento')
+            label_fn = lambda d: f"{d.day:02d}/{d.month:02d}"
+            periods = [start_date + timedelta(days=i) for i in range(0, 30)]
+            is_monthly = False
+
+        # Base queryset within range (date range on date part for performance)
+        base_filter = {
+            'empresa': empresa,
+            'data_lancamento__date__gte': start_date,
+            'data_lancamento__date__lte': end_date if timeframe != '12months' else (now.date()),
+        }
+        qs = LancamentoFinanceiro.objects.filter(**base_filter)
+
+        agg = (
+            qs
+            .annotate(bucket=bucket)
+            .values('bucket')
+            .annotate(
+                inflows=Coalesce(Sum('valor', filter=Q(tipo='entrada')), 0, output_field=DecimalField()),
+                outflows=Coalesce(Sum('valor', filter=Q(tipo='saida')), 0, output_field=DecimalField()),
+            )
+            .order_by('bucket')
+        )
+
+        bucket_to_vals = {}
+        for row in agg:
+            b = row['bucket']
+            # Normalize bucket to date for mapping
+            if is_monthly:
+                normalized = date(b.year, b.month, 1)
+            else:
+                normalized = b if isinstance(b, date) else b.date()
+            bucket_to_vals[normalized] = {
+                'inflows': float(row['inflows']),
+                'outflows': float(row['outflows']),
+            }
+
+        data = []
+        for d in periods:
+            vals = bucket_to_vals.get(d, {'inflows': 0.0, 'outflows': 0.0})
+            net = vals['inflows'] - vals['outflows']
+            data.append({
+                'period': label_fn(d),
+                'inflows': round(vals['inflows'], 2),
+                'outflows': round(vals['outflows'], 2),
+                'net': round(net, 2),
+            })
+
+        return Response({
+            'timeframe': timeframe,
+            'start': start_date,
+            'end': end_date,
+            'data': data,
+        })

--- a/frontend/src/components/financials/FinancialChart.tsx
+++ b/frontend/src/components/financials/FinancialChart.tsx
@@ -1,13 +1,145 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
+import { ComposedChart, Bar, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+import { getCashflowSeries, type CashflowPoint } from '../../services/financialService';
+
+type TimeFrame = '7days' | '30days' | 'currentMonth' | '12months';
+
+interface ChartDataPoint {
+  period: string;
+  inflows: number;
+  outflows: number;
+  net: number;
+}
 
 const FinancialChart = () => {
+  const [timeFrame, setTimeFrame] = useState<TimeFrame>('12months');
+
+  const [chartData, setChartData] = useState<ChartDataPoint[]>([]);
+
+  useEffect(() => {
+    let isCancelled = false;
+    (async () => {
+      try {
+        const data = await getCashflowSeries(timeFrame);
+        if (isCancelled) return;
+        const mapped: ChartDataPoint[] = (data as CashflowPoint[]).map(p => ({
+          period: p.period,
+          inflows: p.inflows,
+          outflows: p.outflows,
+          net: p.net,
+        }));
+        setChartData(mapped);
+      } catch (e) {
+        // fallback to empty
+        if (!isCancelled) setChartData([]);
+        console.error('Erro ao buscar série de fluxo de caixa:', e);
+      }
+    })();
+    return () => { isCancelled = true; };
+  }, [timeFrame]);
+
+  const formatCurrency = (value: number): string => {
+    return new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL' }).format(value);
+  };
+
+  const formatYAxis = (value: number): string => {
+    if (Math.abs(value) >= 1000) {
+      return `R$ ${(value / 1000).toFixed(0)}k`;
+    }
+    return `R$ ${value}`;
+  };
+
   return (
     <div className="bg-white rounded-lg shadow p-6 mb-8">
-      <h3 className="text-lg font-semibold text-gray-700 mb-4">Visão Geral do Mês</h3>
-      <div className="bg-gray-50 rounded-lg h-64 flex items-center justify-center border border-gray-200">
-        <div className="text-center">
-          <p className="text-gray-600 font-medium">Gráfico de Entradas vs. Saídas</p>
-          <p className="text-sm text-gray-400 mt-1">(Componente de gráfico a ser implementado)</p>
+      <div className="flex justify-between items-center mb-4">
+        <h3 className="text-lg font-semibold text-gray-700">Entradas vs. Saídas</h3>
+        
+        <select
+          value={timeFrame}
+          onChange={(e) => setTimeFrame(e.target.value as TimeFrame)}
+          className="px-4 py-2 border border-gray-300 rounded-lg bg-white focus:outline-none focus:ring-2 focus:ring-primary text-sm"
+        >
+          <option value="7days">Últimos 7 dias</option>
+          <option value="30days">Últimos 30 dias</option>
+          <option value="currentMonth">Mês atual</option>
+          <option value="12months">Últimos 12 meses</option>
+        </select>
+      </div>
+
+      <ResponsiveContainer width="100%" height={320}>
+        <ComposedChart
+          data={chartData}
+          margin={{ top: 10, right: 30, left: 20, bottom: 5 }}
+        >
+          <CartesianGrid strokeDasharray="3 3" vertical={false} />
+          <XAxis 
+            dataKey="period" 
+            tick={{ fill: '#6B7280', fontSize: 12 }}
+            angle={timeFrame === '30days' ? -45 : 0}
+            textAnchor={timeFrame === '30days' ? 'end' : 'middle'}
+            height={timeFrame === '30days' ? 60 : 30}
+          />
+          <YAxis 
+            tickFormatter={formatYAxis} 
+            tick={{ fill: '#6B7280' }} 
+            width={70}
+          />
+          <Tooltip
+            formatter={(value: number) => formatCurrency(value)}
+            labelStyle={{ color: '#333', fontWeight: 'bold' }}
+            contentStyle={{ backgroundColor: '#fff', border: '1px solid #ccc', borderRadius: '8px' }}
+          />
+          <Legend 
+            wrapperStyle={{ paddingTop: '10px' }}
+            iconType="rect"
+          />
+          <Bar 
+            dataKey="inflows" 
+            fill="#10B981" 
+            name="Entradas" 
+            radius={[4, 4, 0, 0]}
+            maxBarSize={40}
+          />
+          <Bar 
+            dataKey="outflows" 
+            fill="#F59E0B" 
+            name="Saídas" 
+            radius={[4, 4, 0, 0]}
+            maxBarSize={40}
+          />
+          <Line 
+            type="monotone" 
+            dataKey="net" 
+            stroke="#8B5CF6" 
+            strokeWidth={3}
+            name="Saldo Líquido"
+            dot={{ fill: '#8B5CF6', r: 4 }}
+            activeDot={{ r: 6 }}
+          />
+        </ComposedChart>
+      </ResponsiveContainer>
+
+      {/* Summary Cards */}
+      <div className="grid grid-cols-3 gap-4 mt-6">
+        <div className="bg-green-50 rounded-lg p-3 border border-green-200">
+          <p className="text-xs text-green-600 font-medium mb-1">Total de Entradas</p>
+          <p className="text-lg font-bold text-green-700">
+            {formatCurrency(chartData.reduce((sum, item) => sum + item.inflows, 0))}
+          </p>
+        </div>
+        
+        <div className="bg-orange-50 rounded-lg p-3 border border-orange-200">
+          <p className="text-xs text-orange-600 font-medium mb-1">Total de Saídas</p>
+          <p className="text-lg font-bold text-orange-700">
+            {formatCurrency(chartData.reduce((sum, item) => sum + item.outflows, 0))}
+          </p>
+        </div>
+        
+        <div className="bg-purple-50 rounded-lg p-3 border border-purple-200">
+          <p className="text-xs text-purple-600 font-medium mb-1">Saldo Líquido</p>
+          <p className="text-lg font-bold text-purple-700">
+            {formatCurrency(chartData.reduce((sum, item) => sum + item.net, 0))}
+          </p>
         </div>
       </div>
     </div>

--- a/frontend/src/services/financialService.ts
+++ b/frontend/src/services/financialService.ts
@@ -30,6 +30,13 @@ export interface FinancialStats {
   saldo_atual: number;
 }
 
+export interface CashflowPoint {
+  period: string;
+  inflows: number;
+  outflows: number;
+  net: number;
+}
+
 interface LancamentosParams {
   search?: string;
   categoria?: string;
@@ -49,6 +56,11 @@ export const getFinancialStats = async (): Promise<FinancialStats> => {
 export const getLancamentoCategorias = async (): Promise<string[]> => {
     const response = await api.get('/financeiro/categorias/');
     return response.data;
+};
+
+export const getCashflowSeries = async (timeframe: '7days' | '30days' | 'currentMonth' | '12months' = '12months'): Promise<CashflowPoint[]> => {
+  const response = await api.get('/financeiro/cashflow/', { params: { timeframe } });
+  return response.data.data as CashflowPoint[];
 };
 
 export const createLancamento = async (data: LancamentoFinanceiroData): Promise<LancamentoFinanceiro> => {

--- a/mobile/components/financials/FinancialChart.tsx
+++ b/mobile/components/financials/FinancialChart.tsx
@@ -1,14 +1,217 @@
-import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import React, { useMemo, useState, useEffect } from 'react';
+import { View, Text, StyleSheet, Dimensions, LayoutChangeEvent, ScrollView } from 'react-native';
+import { Picker } from '@react-native-picker/picker';
 import { DashboardColors } from '@/constants/DashboardColors';
+import { getCashflowSeries, type CashflowPoint } from '@/services/FinancialService';
+import { BarChart } from 'react-native-gifted-charts';
+
+type TimeFrame = '7days' | '30days' | 'currentMonth' | '12months';
+
+interface ChartDataPoint {
+  period: string;
+  inflows: number;
+  outflows: number;
+  net: number;
+}
+
+const screenWidth = Dimensions.get('window').width;
 
 const FinancialChart = () => {
+  const [timeFrame, setTimeFrame] = useState<TimeFrame>('12months');
+  const [containerWidth, setContainerWidth] = useState<number>(screenWidth - 40);
+
+  const [chartData, setChartData] = useState<ChartDataPoint[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const data = await getCashflowSeries(timeFrame);
+        if (cancelled) return;
+        const isFiniteNumber = (n: unknown): n is number => typeof n === 'number' && Number.isFinite(n);
+        const mapped: ChartDataPoint[] = (data as CashflowPoint[]).map((p) => ({
+          period: String((p as any)?.period ?? '-'),
+          inflows: isFiniteNumber((p as any)?.inflows) ? (p as any).inflows : 0,
+          outflows: isFiniteNumber((p as any)?.outflows) ? (p as any).outflows : 0,
+          net: isFiniteNumber((p as any)?.net) ? (p as any).net : 0,
+        }));
+        setChartData(mapped);
+      } catch (e) {
+        if (!cancelled) setChartData([]);
+        console.error('Erro ao buscar série de fluxo de caixa (mobile):', e);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [timeFrame]);
+
+  const onContainerLayout = (e: LayoutChangeEvent) => {
+    const { width } = e.nativeEvent.layout;
+    if (width && Math.abs(width - containerWidth) > 1) {
+      setContainerWidth(width);
+    }
+  };
+
+  const formatCurrency = (value: number): string => {
+    return new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL' }).format(value);
+  };
+
+  // Ensure chart-kit always receives at least one data point to avoid crashes on Expo Go
+  const safeData: ChartDataPoint[] = chartData.length > 0
+    ? chartData
+    : [{ period: '-', inflows: 0, outflows: 0, net: 0 }];
+
+  const totalInflows = chartData.reduce((sum, item) => sum + item.inflows, 0);
+  const totalOutflows = chartData.reduce((sum, item) => sum + item.outflows, 0);
+  const totalNet = chartData.reduce((sum, item) => sum + item.net, 0);
+
+  // Compute dynamic bar width and scrollable chart content width
+  const desiredVisibleBars = useMemo(() => (timeFrame === '12months' ? 12 : timeFrame === '7days' ? 7 : 12), [timeFrame]);
+  const barSpacing = 6;
+  const sidePadding = 48; // approximate space for axes/labels used by the chart
+  const computedBarWidth = useMemo(() => {
+    const numberOfBars = Math.max(1, safeData.length);
+    // If we have few bars, expand bars to fill available width (no scroll)
+    if (numberOfBars <= desiredVisibleBars) {
+      const available = Math.max(0, containerWidth - sidePadding - (numberOfBars - 1) * barSpacing);
+      const widthPerBar = Math.floor(available / numberOfBars);
+      return Math.max(18, Math.min(64, widthPerBar));
+    }
+    // Otherwise, target a reasonable width per desired visible bars
+    const maxWidthPerBar = Math.floor(containerWidth / Math.max(1, desiredVisibleBars));
+    return Math.max(14, Math.min(34, maxWidthPerBar - barSpacing));
+  }, [containerWidth, desiredVisibleBars, safeData.length]);
+  const chartContentWidth = useMemo(() => {
+    const numberOfBars = safeData.length;
+    const contentBase = numberOfBars > 0
+      ? numberOfBars * (computedBarWidth + barSpacing) - barSpacing + sidePadding
+      : containerWidth;
+    return Math.max(containerWidth, contentBase);
+  }, [safeData.length, computedBarWidth, containerWidth]);
+
+  // Axis labels: compress and optionally rotate
+  const targetLabels = useMemo(() => (timeFrame === '12months' ? 12 : timeFrame === '7days' ? 7 : 10), [timeFrame]);
+  const stride = useMemo(() => Math.max(1, Math.ceil(safeData.length / targetLabels)), [safeData.length, targetLabels]);
+  const angle = useMemo(() => ((timeFrame === '30days' || timeFrame === 'currentMonth') ? -35 : 0), [timeFrame]);
+
+  // Colors
+  const colorInflows = '#10B981';
+  const colorOutflows = '#F59E0B';
+  const colorNet = '#8B5CF6';
+
+  // Gifted Charts data: stacked bars + overlay line
+  const stackData = useMemo(() => (
+    safeData.map((p, idx) => ({
+      label: idx % stride === 0 ? p.period : '',
+      stacks: [
+        { value: p.inflows, color: colorInflows },
+        { value: p.outflows, color: colorOutflows },
+      ],
+    }))
+  ), [safeData, stride]);
+
+  const lineData = useMemo(() => (
+    safeData.map(p => ({ value: Number.isFinite(p.net) ? p.net : 0 }))
+  ), [safeData]);
+
+  const maxStack = useMemo(() => (
+    safeData.reduce((m, p) => Math.max(m, p.inflows + p.outflows, p.net), 0)
+  ), [safeData]);
+  const hasAtLeastTwoPoints = safeData.length >= 2;
+  const chartKey = useMemo(() => `tf-${timeFrame}-${safeData.length}`, [timeFrame, safeData.length]);
+
   return (
-    <View style={styles.container}>
-      <Text style={styles.title}>Visão Geral do Mês</Text>
-      <View style={styles.chartPlaceholder}>
-        <Text style={styles.placeholderText}>Gráfico de Entradas vs. Saídas</Text>
-        <Text style={styles.placeholderSubText}>(Componente em desenvolvimento)</Text>
+    <View style={styles.container} onLayout={onContainerLayout}>
+      <View style={styles.header}>
+        <Text style={styles.title}>Entradas vs. Saídas</Text>
+      </View>
+
+      <View style={styles.pickerContainer}>
+        <Picker
+          selectedValue={timeFrame}
+          onValueChange={(value) => setTimeFrame(value as TimeFrame)}
+          style={styles.picker}
+        >
+          <Picker.Item label="Últimos 7 dias" value="7days" />
+          <Picker.Item label="Últimos 30 dias" value="30days" />
+          <Picker.Item label="Mês atual" value="currentMonth" />
+          <Picker.Item label="Últimos 12 meses" value="12months" />
+        </Picker>
+      </View>
+
+      {/* Scrollable gifted-charts bar + line (overlay) */}
+      <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={{ width: chartContentWidth }}>
+        <View style={{ width: chartContentWidth, paddingBottom: 12 }}>
+          <BarChart
+            key={chartKey}
+            width={chartContentWidth}
+            height={220}
+            stackData={stackData}
+            barWidth={computedBarWidth}
+            spacing={barSpacing}
+            yAxisTextStyle={{ color: '#6B7280', fontSize: 10 }}
+            xAxisLabelTextStyle={{ color: '#6B7280', fontSize: 10, transform: [{ rotate: `${angle}deg` }] }}
+            xAxisThickness={0.75}
+            yAxisThickness={0.75}
+            rulesType={'solid'}
+            rulesColor={'#e5e7eb'}
+            noOfSections={5}
+            maxValue={Math.max(1, Math.ceil(maxStack * 1.2))}
+            showLine={hasAtLeastTwoPoints}
+            lineData={lineData}
+            lineConfig={{ color: colorNet, thickness: 3, curved: true, hideDataPoints: false, dataPointsWidth: 4, dataPointsColor: colorNet }}
+            renderTooltip={(item: any, index: number) => {
+              const p = safeData[index] || { period: '', inflows: 0, outflows: 0, net: 0 };
+              return (
+                <View style={{ backgroundColor: 'white', borderRadius: 8, padding: 8, borderWidth: 1, borderColor: '#e5e7eb' }}>
+                  <Text style={{ color: '#111827', fontWeight: '600', marginBottom: 4 }}>{p.period}</Text>
+                  <Text style={{ color: colorInflows }}>Entradas: {formatCurrency(p.inflows)}</Text>
+                  <Text style={{ color: colorOutflows }}>Saídas: {formatCurrency(p.outflows)}</Text>
+                  <Text style={{ color: colorNet }}>Saldo: {formatCurrency(p.net)}</Text>
+                </View>
+              );
+            }}
+          />
+        </View>
+      </ScrollView>
+
+      {/* Legend */}
+      <View style={{ flexDirection: 'row', justifyContent: 'center', gap: 12, marginTop: 10 }}>
+        <View style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}>
+          <View style={{ width: 12, height: 12, backgroundColor: colorInflows, borderRadius: 2 }} />
+          <Text style={{ color: '#374151', fontSize: 12 }}>Entradas</Text>
+        </View>
+        <View style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}>
+          <View style={{ width: 12, height: 12, backgroundColor: colorOutflows, borderRadius: 2 }} />
+          <Text style={{ color: '#374151', fontSize: 12 }}>Saídas</Text>
+        </View>
+        <View style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}>
+          <View style={{ width: 12, height: 2, backgroundColor: colorNet }} />
+          <Text style={{ color: '#374151', fontSize: 12 }}>Saldo</Text>
+        </View>
+      </View>
+
+      {/* Summary Cards */}
+      <View style={styles.summaryContainer}>
+        <View style={styles.summaryCard}>
+          <Text style={styles.summaryLabel}>Entradas</Text>
+          <Text style={[styles.summaryValue, { color: '#10B981' }]}>
+            {formatCurrency(totalInflows)}
+          </Text>
+        </View>
+        
+        <View style={styles.summaryCard}>
+          <Text style={styles.summaryLabel}>Saídas</Text>
+          <Text style={[styles.summaryValue, { color: '#F59E0B' }]}>
+            {formatCurrency(totalOutflows)}
+          </Text>
+        </View>
+        
+        <View style={styles.summaryCard}>
+          <Text style={styles.summaryLabel}>Líquido</Text>
+          <Text style={[styles.summaryValue, { color: '#8B5CF6' }]}>
+            {formatCurrency(totalNet)}
+          </Text>
+        </View>
       </View>
     </View>
   );
@@ -17,35 +220,75 @@ const FinancialChart = () => {
 const styles = StyleSheet.create({
   container: {
     backgroundColor: 'white',
-    borderRadius: 8,
-    padding: 15,
-    marginHorizontal: 20,
-    marginBottom: 20,
+    borderRadius: 12,
+    padding: 16,
+    marginBottom: 16,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.1,
+    shadowRadius: 4,
+    elevation: 3,
+  },
+  chartWrapper: {
+    position: 'relative',
+    overflow: 'hidden',
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 12,
   },
   title: {
     fontSize: 16,
     fontWeight: 'bold',
     color: DashboardColors.darkText,
-    marginBottom: 10,
   },
-  chartPlaceholder: {
-    height: 150,
-    backgroundColor: '#f8f9fa',
-    justifyContent: 'center',
-    alignItems: 'center',
-    borderRadius: 8,
+  pickerContainer: {
     borderWidth: 1,
-    borderColor: '#eee',
+    borderColor: '#D1D5DB',
+    borderRadius: 8,
+    marginBottom: 16,
+    backgroundColor: '#F9FAFB',
   },
-  placeholderText: {
+  picker: {
+    height: 50,
+  },
+  chart: {
+    marginVertical: 8,
+    borderRadius: 16,
+  },
+  lineOverlay: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+  },
+  summaryContainer: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginTop: 16,
+    gap: 8,
+  },
+  summaryCard: {
+    flex: 1,
+    backgroundColor: '#F3F4F6',
+    borderRadius: 8,
+    padding: 10,
+    alignItems: 'center',
+  },
+  summaryLabel: {
+    fontSize: 10,
     color: DashboardColors.grayText,
-    fontWeight: '500',
+    fontWeight: '600',
+    marginBottom: 4,
+    textAlign: 'center',
   },
-  placeholderSubText: {
-      fontSize: 12,
-      color: '#ccc',
-      marginTop: 4,
-  }
+  summaryValue: {
+    fontSize: 12,
+    fontWeight: 'bold',
+    textAlign: 'center',
+  },
 });
 
 export default FinancialChart;

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@expo/vector-icons": "^15.0.2",
+        "@react-native-picker/picker": "^2.11.4",
         "@react-navigation/bottom-tabs": "^7.3.10",
         "@react-navigation/elements": "^2.3.8",
         "@react-navigation/native": "^7.1.6",
@@ -36,6 +37,7 @@
         "react-native": "0.81.4",
         "react-native-chart-kit": "^6.12.0",
         "react-native-gesture-handler": "~2.28.0",
+        "react-native-gifted-charts": "^1.4.64",
         "react-native-reanimated": "~4.1.0",
         "react-native-safe-area-context": "~5.6.0",
         "react-native-screens": "~4.16.0",
@@ -94,7 +96,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.4.tgz",
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -1387,6 +1388,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.27.1.tgz",
       "integrity": "sha512-fBJKiV7F2DxZUkg5EtHKXQdbsbURW3DZKQUWphDum0uRP6eHGGa/He9mc0mypL680pb+e/lDIthRohlv8NCHkg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
       },
@@ -3174,6 +3176,19 @@
         }
       }
     },
+    "node_modules/@react-native-picker/picker": {
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/@react-native-picker/picker/-/picker-2.11.4.tgz",
+      "integrity": "sha512-Kf8h1AMnBo54b1fdiVylP2P/iFcZqzpMYcglC28EEFB1DEnOjsNr6Ucqc+3R9e91vHxEDnhZFbYDmAe79P2gjA==",
+      "license": "MIT",
+      "workspaces": [
+        "example"
+      ],
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/@react-native/assets-registry": {
       "version": "0.81.4",
       "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.81.4.tgz",
@@ -3489,7 +3504,6 @@
       "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-7.1.17.tgz",
       "integrity": "sha512-uEcYWi1NV+2Qe1oELfp9b5hTYekqWATv2cuwcOAg5EvsIsUPtzFrKIasgUXLBRGb9P7yR5ifoJ+ug4u6jdqSTQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@react-navigation/core": "^7.12.4",
         "escape-string-regexp": "^4.0.0",
@@ -3686,7 +3700,6 @@
       "integrity": "sha512-hHkbU/eoO3EG5/MZkuFSKmYqPbSVk5byPFa3e7y/8TybHiLMACgI8seVYlicwk7H5K/rI2px9xrQp/C+AUDTiQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -3758,7 +3771,6 @@
       "integrity": "sha512-r1XG74QgShUgXph1BYseJ+KZd17bKQib/yF3SR+demvytiRXrwd12Blnz5eYGm8tXaeRdd4x88MlfwldHoudGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.42.0",
         "@typescript-eslint/types": "8.42.0",
@@ -4321,7 +4333,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5033,7 +5044,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001737",
         "electron-to-chromium": "^1.5.211",
@@ -6303,7 +6313,6 @@
       "integrity": "sha512-QePbBFMJFjgmlE+cXAlbHZbHpdFVS2E/6vzCy7aKlebddvl1vadiC4JFV5u/wqTkNUwEV8WrQi257jf5f06hrg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6501,7 +6510,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -6740,7 +6748,6 @@
       "resolved": "https://registry.npmjs.org/expo/-/expo-54.0.6.tgz",
       "integrity": "sha512-fzOrhdMNJiNlQyj7Gj1GvEzwIx1XaOLWRVOoTtaOkWckYJzgsTnnUQhFFGEfb8Vv0tZGeWzx6CFXqjcraxYT7g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.20.0",
         "@expo/cli": "54.0.4",
@@ -6819,7 +6826,6 @@
       "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-18.0.8.tgz",
       "integrity": "sha512-Tetphsx6RVImCTZeBAclRQMy0WOODY3y6qrUoc88YGUBVm8fAKkErCSWxLTCc6nFcJxdoOMYi62LgNIUFjZCLA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@expo/config": "~12.0.8",
         "@expo/env": "~2.0.7"
@@ -6844,7 +6850,6 @@
       "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-14.0.8.tgz",
       "integrity": "sha512-bTUHaJWRZ7ywP8dg3f+wfOwv6RwMV3mWT2CDUIhsK70GjNGlCtiWOCoHsA5Od/esPaVxqc37cCBvQGQRFStRlA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fontfaceobserver": "^2.1.0"
       },
@@ -6927,7 +6932,6 @@
       "resolved": "https://registry.npmjs.org/expo-linking/-/expo-linking-8.0.8.tgz",
       "integrity": "sha512-MyeMcbFDKhXh4sDD1EHwd0uxFQNAc6VCrwBkNvvvufUsTYFq3glTA9Y8a+x78CPpjNqwNAamu74yIaIz7IEJyg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "expo-constants": "~18.0.8",
         "invariant": "^2.2.4"
@@ -7765,6 +7769,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/gifted-charts-core": {
+      "version": "0.1.66",
+      "resolved": "https://registry.npmjs.org/gifted-charts-core/-/gifted-charts-core-0.1.66.tgz",
+      "integrity": "sha512-qbfgxjrInrWpnomvrjVARF76uPj3JllKySxMgslQRKIe0ehIuD58mRY5qP3iFzD96ngPcxsTy5M0cFbXqykJdA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*",
+        "react-native-svg": "*"
       }
     },
     "node_modules/glob": {
@@ -10925,7 +10940,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10945,7 +10959,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -10982,7 +10995,6 @@
       "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.81.4.tgz",
       "integrity": "sha512-bt5bz3A/+Cv46KcjV0VQa+fo7MKxs17RCcpzjftINlen4ZDUl0I6Ut+brQ2FToa5oD0IB0xvQHfmsg2EDqsZdQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/create-cache-key-function": "^29.7.0",
         "@react-native/assets-registry": "0.81.4",
@@ -11056,7 +11068,6 @@
       "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.28.0.tgz",
       "integrity": "sha512-0msfJ1vRxXKVgTgvL+1ZOoYw3/0z1R+Ked0+udoJhyplC2jbVKIJ8Z1bzWdpQRCV3QcQ87Op0zJVE5DhKK2A0A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@egjs/hammerjs": "^2.0.17",
         "hoist-non-react-statics": "^3.3.0",
@@ -11065,6 +11076,30 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/react-native-gifted-charts": {
+      "version": "1.4.64",
+      "resolved": "https://registry.npmjs.org/react-native-gifted-charts/-/react-native-gifted-charts-1.4.64.tgz",
+      "integrity": "sha512-jbr6RZ/61skhC7z5BKAu4e5jsWgVnmjU5UoVW3DO9rcqDpeqdIQzNoqmazjuHa7NvDjfKNey6FdblFTkvnBHdQ==",
+      "license": "MIT",
+      "dependencies": {
+        "gifted-charts-core": "0.1.66"
+      },
+      "peerDependencies": {
+        "expo-linear-gradient": "*",
+        "react": "*",
+        "react-native": "*",
+        "react-native-linear-gradient": "*",
+        "react-native-svg": "*"
+      },
+      "peerDependenciesMeta": {
+        "expo-linear-gradient": {
+          "optional": true
+        },
+        "react-native-linear-gradient": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-native-is-edge-to-edge": {
@@ -11110,7 +11145,6 @@
       "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-5.6.1.tgz",
       "integrity": "sha512-/wJE58HLEAkATzhhX1xSr+fostLsK8Q97EfpfMDKo8jlOc1QKESSX/FQrhk7HhQH/2uSaox4Y86sNaI02kteiA==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
@@ -11121,7 +11155,6 @@
       "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.16.0.tgz",
       "integrity": "sha512-yIAyh7F/9uWkOzCi1/2FqvNvK6Wb9Y1+Kzn16SuGfN9YFJDTbwlzGRvePCNTOX0recpLQF3kc2FmvMUhyTCH1Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "react-freeze": "^1.0.0",
         "react-native-is-edge-to-edge": "^1.2.1",
@@ -11152,7 +11185,6 @@
       "resolved": "https://registry.npmjs.org/react-native-web/-/react-native-web-0.21.1.tgz",
       "integrity": "sha512-BeNsgwwe4AXUFPAoFU+DKjJ+CVQa3h54zYX77p7GVZrXiiNo3vl03WYDYVEy5R2J2HOPInXtQZB5gmj3vuzrKg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.6",
         "@react-native/normalize-colors": "^0.74.1",
@@ -11185,7 +11217,6 @@
       "resolved": "https://registry.npmjs.org/react-native-webview/-/react-native-webview-13.15.0.tgz",
       "integrity": "sha512-Vzjgy8mmxa/JO6l5KZrsTC7YemSdq+qB01diA0FqjUTaWGAGwuykpJ73MDj3+mzBSlaDxAEugHzTtkUQkQEQeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "escape-string-regexp": "^4.0.0",
         "invariant": "2.2.4"
@@ -11200,6 +11231,7 @@
       "resolved": "https://registry.npmjs.org/react-native-worklets/-/react-native-worklets-0.5.1.tgz",
       "integrity": "sha512-lJG6Uk9YuojjEX/tQrCbcbmpdLCSFxDK1rJlkDhgqkVi1KZzG7cdcBFQRqyNOOzR9Y0CXNuldmtWTGOyM0k0+w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/plugin-transform-arrow-functions": "^7.0.0-0",
         "@babel/plugin-transform-class-properties": "^7.0.0-0",
@@ -11237,6 +11269,7 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
       "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "license": "ISC",
+      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -11300,7 +11333,6 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
       "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13035,7 +13067,6 @@
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@expo/vector-icons": "^15.0.2",
+    "@react-native-picker/picker": "^2.11.4",
     "@react-navigation/bottom-tabs": "^7.3.10",
     "@react-navigation/elements": "^2.3.8",
     "@react-navigation/native": "^7.1.6",
@@ -39,6 +40,7 @@
     "react-native": "0.81.4",
     "react-native-chart-kit": "^6.12.0",
     "react-native-gesture-handler": "~2.28.0",
+    "react-native-gifted-charts": "^1.4.64",
     "react-native-reanimated": "~4.1.0",
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.16.0",

--- a/mobile/services/FinancialService.ts
+++ b/mobile/services/FinancialService.ts
@@ -23,6 +23,13 @@ export interface FinancialStats {
   saldo_atual: number;
 }
 
+export interface CashflowPoint {
+  period: string;
+  inflows: number;
+  outflows: number;
+  net: number;
+}
+
 export interface PaginatedLancamentos {
   count: number;
   next: string | null;
@@ -64,4 +71,11 @@ export const updateLancamento = async (id: number, data: LancamentoFinanceiroDat
 
 export const deleteLancamento = async (id: number): Promise<void> => {
   await api.delete(`/financeiro/lancamentos/${id}/`);
+};
+
+export const getCashflowSeries = async (
+  timeframe: '7days' | '30days' | 'currentMonth' | '12months' = '12months'
+): Promise<CashflowPoint[]> => {
+  const response = await api.get('/financeiro/cashflow/', { params: { timeframe } });
+  return response.data.data as CashflowPoint[];
 };


### PR DESCRIPTION
This pull request introduces a new cash flow time series API endpoint on the backend and integrates it into both the web and mobile financial dashboards. Users can now visualize inflows, outflows, and net cash flow over selectable periods (7 days, 30 days, current month, or last 12 months). The frontend and mobile apps have been updated to fetch and display this data in interactive charts, providing a clearer financial overview.

**Backend: Cash Flow API**
- Added a new endpoint `financeiro/cashflow/` that aggregates inflows, outflows, and net cash flow for the authenticated user's company over selectable timeframes (7 days, 30 days, current month, or 12 months). The data is bucketed by day or month and returned in a format suitable for charting. [[1]](diffhunk://#diff-70ac01b1d23fd211fd9dee821f4346e7cf89b6e90a408176e89a9bb4016fe4d0L2-R10) [[2]](diffhunk://#diff-7a9c72e95d4172f5ba535bae59941c7c2678f478d8f2950d648aed16cc40fdc1R191-R303)

**Frontend Web: Chart Integration**
- Implemented the `getCashflowSeries` service to fetch cash flow data from the new backend endpoint, and defined the `CashflowPoint` type for type safety. [[1]](diffhunk://#diff-622fa4396c182d7112d15c22b56deafad9ece176a69534076a8b6a404d500208R33-R39) [[2]](diffhunk://#diff-622fa4396c182d7112d15c22b56deafad9ece176a69534076a8b6a404d500208R61-R65)
- Replaced the placeholder in `FinancialChart.tsx` with a dynamic chart using `recharts`, allowing users to select the timeframe and view inflows, outflows, and net values. Includes summary cards for totals.

**Mobile App: Chart Integration**
- Updated the mobile `FinancialChart.tsx` to fetch and display the new cash flow series using a scrollable stacked bar and line chart (via `react-native-gifted-charts`). Users can select the timeframe, and summary cards show totals for each period.