### PR TITLE
feature: Implementa armazenamento de mídia usando Buckets do Google Cloud Storage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/*
 
 # Set environment variables for Gunicorn
-ENV GUNICORN_CMD_ARGS="--workers=2 --threads=4 --worker-class=gthread --bind=0.0.0.0:8080"
+# --preload loads the app in the master so config errors exit before workers spawn
+# --log-level error reduces Gunicorn's own verbosity on failure
+ENV GUNICORN_CMD_ARGS="--workers=2 --threads=4 --worker-class=gthread --bind=0.0.0.0:8080 --preload --log-level error"
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 

--- a/backend/ezgestor_api/settings.py
+++ b/backend/ezgestor_api/settings.py
@@ -14,6 +14,7 @@ import os
 from pathlib import Path
 import dj_database_url
 from datetime import timedelta
+from django.core.exceptions import ImproperlyConfigured
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -243,6 +244,35 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 AUTH_USER_MODEL = 'accounts.Usuario'
 
-# Media files (uploaded product images)
-MEDIA_URL = os.environ.get('MEDIA_URL', '/media/')
-MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
+# Media files (uploaded product images) with unified cloud/local switch
+# Default to local mode (no .env required)
+USE_CLOUD_BACKENDS = _env_flag('USE_CLOUD_BACKENDS', 'False')
+
+# Media backend follows the unified switch
+USE_GCS_MEDIA = USE_CLOUD_BACKENDS
+
+if USE_GCS_MEDIA:
+    # Use Google Cloud Storage for media
+    INSTALLED_APPS.append('storages')
+    DEFAULT_FILE_STORAGE = 'storages.backends.gcloud.GoogleCloudStorage'
+    GS_BUCKET_NAME = os.environ.get('GS_BUCKET_NAME')
+    if not GS_BUCKET_NAME:
+        raise ImproperlyConfigured('USE_CLOUD_BACKENDS=True requires GS_BUCKET_NAME to be set.')
+    GS_QUERYSTRING_AUTH = False  # public URLs
+    GS_DEFAULT_ACL = None        # uniform bucket-level access
+    # Compose the media base URL from the bucket name (stable host)
+    MEDIA_URL = f"https://storage.googleapis.com/{GS_BUCKET_NAME}/"
+else:
+    # Legacy local filesystem media
+    MEDIA_URL = '/media/'
+    MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
+
+# Enforce coupling between database and media backends to avoid mixed setups
+_db_engine = DATABASES['default']['ENGINE']
+_is_sqlite = _db_engine.endswith('sqlite3')
+_is_cloud_db = not _is_sqlite
+
+if USE_CLOUD_BACKENDS and _is_sqlite:
+    raise ImproperlyConfigured('USE_CLOUD_BACKENDS=True requires non-sqlite DATABASE_URL (Cloud SQL).')
+if not USE_CLOUD_BACKENDS and (_is_cloud_db or USE_GCS_MEDIA):
+    raise ImproperlyConfigured('USE_CLOUD_BACKENDS=False requires SQLite and local media.')

--- a/backend/ezgestor_api/settings.py
+++ b/backend/ezgestor_api/settings.py
@@ -248,6 +248,24 @@ AUTH_USER_MODEL = 'accounts.Usuario'
 # Default to local mode (no .env required)
 USE_CLOUD_BACKENDS = _env_flag('USE_CLOUD_BACKENDS', 'False')
 
+def _is_set_env(name: str) -> bool:
+    value = os.environ.get(name)
+    return bool(value and value.strip())
+
+# Validate required env set for cloud mode before configuring storage
+if USE_CLOUD_BACKENDS:
+    missing = []
+    if not _is_set_env('GS_BUCKET_NAME'):
+        missing.append('GS_BUCKET_NAME')
+    if not _is_set_env('DATABASE_URL'):
+        missing.append('DATABASE_URL')
+    if not _is_set_env('CLOUD_SQL_CONNECTION_NAME'):
+        missing.append('CLOUD_SQL_CONNECTION_NAME')
+    if missing:
+        raise ImproperlyConfigured(
+            f"USE_CLOUD_BACKENDS=True requires these env vars: {', '.join(missing)}."
+        )
+
 # Media backend follows the unified switch
 USE_GCS_MEDIA = USE_CLOUD_BACKENDS
 
@@ -255,9 +273,7 @@ if USE_GCS_MEDIA:
     # Use Google Cloud Storage for media
     INSTALLED_APPS.append('storages')
     DEFAULT_FILE_STORAGE = 'storages.backends.gcloud.GoogleCloudStorage'
-    GS_BUCKET_NAME = os.environ.get('GS_BUCKET_NAME')
-    if not GS_BUCKET_NAME:
-        raise ImproperlyConfigured('USE_CLOUD_BACKENDS=True requires GS_BUCKET_NAME to be set.')
+    GS_BUCKET_NAME = os.environ['GS_BUCKET_NAME']
     GS_QUERYSTRING_AUTH = False  # public URLs
     GS_DEFAULT_ACL = None        # uniform bucket-level access
     # Compose the media base URL from the bucket name (stable host)
@@ -272,7 +288,15 @@ _db_engine = DATABASES['default']['ENGINE']
 _is_sqlite = _db_engine.endswith('sqlite3')
 _is_cloud_db = not _is_sqlite
 
-if USE_CLOUD_BACKENDS and _is_sqlite:
-    raise ImproperlyConfigured('USE_CLOUD_BACKENDS=True requires non-sqlite DATABASE_URL (Cloud SQL).')
-if not USE_CLOUD_BACKENDS and (_is_cloud_db or USE_GCS_MEDIA):
-    raise ImproperlyConfigured('USE_CLOUD_BACKENDS=False requires SQLite and local media.')
+if USE_CLOUD_BACKENDS:
+    if _is_sqlite:
+        raise ImproperlyConfigured('USE_CLOUD_BACKENDS=True requires non-sqlite DATABASE_URL (Cloud SQL).')
+else:
+    # Offline/local mode must not use cloud DB or cloud-only identifiers
+    if _is_cloud_db:
+        raise ImproperlyConfigured('USE_CLOUD_BACKENDS=False requires SQLite database.')
+    # Treat empty string as unset to align with docker-compose defaults
+    if _is_set_env('GS_BUCKET_NAME') or _is_set_env('CLOUD_SQL_CONNECTION_NAME'):
+        raise ImproperlyConfigured(
+            'USE_CLOUD_BACKENDS=False requires GS_BUCKET_NAME and CLOUD_SQL_CONNECTION_NAME to be unset.'
+        )

--- a/backend/ezgestor_api/wsgi.py
+++ b/backend/ezgestor_api/wsgi.py
@@ -8,9 +8,17 @@ https://docs.djangoproject.com/en/5.2/howto/deployment/wsgi/
 """
 
 import os
+import sys
 
 from django.core.wsgi import get_wsgi_application
+from django.core.exceptions import ImproperlyConfigured
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'ezgestor_api.settings')
 
-application = get_wsgi_application()
+# Gracefully handle configuration errors to avoid verbose stack traces in container logs
+try:
+    application = get_wsgi_application()
+except ImproperlyConfigured as exc:
+    sys.stderr.write(f"Configuration error: {exc}\n")
+    sys.stderr.flush()
+    os._exit(3)

--- a/backend/manage.py
+++ b/backend/manage.py
@@ -9,13 +9,19 @@ def main():
     os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'ezgestor_api.settings')
     try:
         from django.core.management import execute_from_command_line
+        from django.core.exceptions import ImproperlyConfigured
     except ImportError as exc:
         raise ImportError(
             "Couldn't import Django. Are you sure it's installed and "
             "available on your PYTHONPATH environment variable? Did you "
             "forget to activate a virtual environment?"
         ) from exc
-    execute_from_command_line(sys.argv)
+    try:
+        execute_from_command_line(sys.argv)
+    except ImproperlyConfigured as exc:
+        sys.stderr.write(f"Configuration error: {exc}\n")
+        sys.stderr.flush()
+        sys.exit(3)
 
 
 if __name__ == '__main__':

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,3 +12,5 @@ mysqlclient==2.2.4
 Pillow
 WeasyPrint==61.2
 xhtml2pdf==0.2.15
+django-storages==1.14.4
+google-cloud-storage==2.18.2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       CSRF_TRUSTED_ORIGINS: ${CSRF_TRUSTED_ORIGINS:-http://localhost:19006,http://127.0.0.1:19006}
       # Default to a persistent SQLite file inside the volume-backed directory
       DATABASE_URL: ${DATABASE_URL:-sqlite:////app/sqlite-data/db.sqlite3}
+      CLOUD_SQL_CONNECTION_NAME: ${CLOUD_SQL_CONNECTION_NAME:-}
       CONN_MAX_AGE: ${CONN_MAX_AGE:-0}
       # Unified cloud switch defaults to False (local mode requires no .env)
       USE_CLOUD_BACKENDS: ${USE_CLOUD_BACKENDS:-False}
@@ -40,6 +41,7 @@ services:
       CSRF_TRUSTED_ORIGINS: ${CSRF_TRUSTED_ORIGINS:-http://localhost:19006,http://127.0.0.1:19006}
       # Match the web default so migrations hit the same DB by default
       DATABASE_URL: ${DATABASE_URL:-sqlite:////app/sqlite-data/db.sqlite3}
+      CLOUD_SQL_CONNECTION_NAME: ${CLOUD_SQL_CONNECTION_NAME:-}
       CONN_MAX_AGE: ${CONN_MAX_AGE:-0}
       USE_CLOUD_BACKENDS: ${USE_CLOUD_BACKENDS:-False}
       GS_BUCKET_NAME: ${GS_BUCKET_NAME:-}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - "8000:8080"
     volumes:
       - db_data:/app/sqlite-data
+      - ./secrets:/secrets:ro
     environment:
       DEBUG: ${DEBUG:-True}
       ALLOWED_HOSTS: ${ALLOWED_HOSTS:-*}
@@ -19,6 +20,12 @@ services:
       # Default to a persistent SQLite file inside the volume-backed directory
       DATABASE_URL: ${DATABASE_URL:-sqlite:////app/sqlite-data/db.sqlite3}
       CONN_MAX_AGE: ${CONN_MAX_AGE:-0}
+      # Unified cloud switch defaults to False (local mode requires no .env)
+      USE_CLOUD_BACKENDS: ${USE_CLOUD_BACKENDS:-False}
+      # GCS bucket name (required only when USE_CLOUD_BACKENDS=True)
+      GS_BUCKET_NAME: ${GS_BUCKET_NAME:-}
+      # Fixed path inside container to the service account json
+      GOOGLE_APPLICATION_CREDENTIALS: /secrets/sa.json
 
   migrate:
     build:
@@ -34,9 +41,13 @@ services:
       # Match the web default so migrations hit the same DB by default
       DATABASE_URL: ${DATABASE_URL:-sqlite:////app/sqlite-data/db.sqlite3}
       CONN_MAX_AGE: ${CONN_MAX_AGE:-0}
+      USE_CLOUD_BACKENDS: ${USE_CLOUD_BACKENDS:-False}
+      GS_BUCKET_NAME: ${GS_BUCKET_NAME:-}
+      GOOGLE_APPLICATION_CREDENTIALS: /secrets/sa.json
     volumes:
       - db_data:/app/sqlite-data
       - ./backend:/app
+      - ./secrets:/secrets:ro
     restart: "no"
 
   cloudsql-proxy:


### PR DESCRIPTION
### Este PR implementa o Google Cloud Storage (GCS) para arquivos de mídia do Django (ex.: imagens de produtos), mantendo compatibilidade com o armazenamento local existente. Introduz uma única variável de ambiente (`USE_CLOUD_BACKENDS`) para acoplar os backends de mídia e banco de dados, garantindo apenas dois modos válidos: totalmente local (SQLite + mídia em filesystem) ou totalmente cloud (Cloud SQL + GCS). Configurações mistas agora falham de forma graciosa com mensagens de erro concisas, reduzindo ruído nos logs do Docker/Cloud Run.

#### Principais Mudanças
- **Dependências** (`backend/requirements.txt`):
  - Adicionado `django-storages==1.14.4` e `google-cloud-storage==2.18.2` para integração com GCS.

- **Configuração de Settings** (`backend/ezgestor_api/settings.py`):
  - Adicionada variável `USE_CLOUD_BACKENDS` (padrão `False` para modo local sem `.env`).
  - Quando `True`: Ativa app `storages`, define `DEFAULT_FILE_STORAGE` para GCS, exige `GS_BUCKET_NAME`, `DATABASE_URL` (não-SQLite) e `CLOUD_SQL_CONNECTION_NAME`. Compõe `MEDIA_URL` como `https://storage.googleapis.com/{GS_BUCKET_NAME}/` (sem necessidade de override via env).
  - Quando `False`: Retorna ao filesystem legado `/media/` (`MEDIA_ROOT = BASE_DIR / 'media'`).
  - Validação rigorosa: Levanta `ImproperlyConfigured` para vars cloud ausentes ou incompatibilidades (ex.: DB cloud no modo local). Permite vars extras (ex.: `DEBUG`, `CSRF_TRUSTED_ORIGINS`) sem falhar.
  - Adicionado helper `_is_set_env` para verificar vars não vazias.

- **Wiring no Docker Compose** (`docker-compose.yml`):
  - Adicionadas vars de ambiente para serviços `web` e `migrate`: `USE_CLOUD_BACKENDS: ${USE_CLOUD_BACKENDS:-False}`, `GS_BUCKET_NAME: ${GS_BUCKET_NAME:-}`, `CLOUD_SQL_CONNECTION_NAME: ${CLOUD_SQL_CONNECTION_NAME:-}`.
  - Definido `GOOGLE_APPLICATION_CREDENTIALS: /secrets/sa.json` fixo para modo cloud local no Docker.
  - Montado `./secrets:/secrets:ro` para acesso ao JSON da conta de serviço em `web` e `migrate`.
  - Mantido `DATABASE_URL` padrão para SQLite para modo local fluido (sem `.env` obrigatório).

- **Ajustes no Gunicorn** (`Dockerfile`):
  - Adicionado `--preload` para carregar o app no processo master (erros de config saem antes de spawnar workers).
  - Definido `--log-level error` para minimizar verbosidade do Gunicorn em falhas.

- **Tratamento Gracioso de Erros**:
  - `backend/ezgestor_api/wsgi.py`: Captura `ImproperlyConfigured` durante init WSGI, imprime "Configuration error: ..." conciso no stderr e sai com código 3 (sem traceback completo).
  - `backend/manage.py`: Handler similar para comandos de migração (ex.: `python manage.py migrate`).

#### Benefícios
- **Dev Local Sem Complicações**: Sem `.env` para SQLite + mídia local; basta `docker compose up -d`.
- **Consistência Cloud**: Garante setup tudo-ou-nada cloud (evita configs parciais como DB local com GCS).
- **Logs Limpos**: Misconfigs imprimem uma linha de erro em vez de traces verbosos no Docker/Cloud Run.
- **Pronto para Produção**: GCS lida com armazenamento efêmero do Cloud Run; URLs públicas funcionam nativamente (ou use URLs assinadas opcionalmente).
- **Sem Quebras**: Fluxo de mídia local existente inalterado; `ImageField` nos models (ex.: `estoque/models.py`) funciona transparentemente.

#### Uso
- **Modo Local** (padrão, sem `.env`):
  ```
  docker compose up -d
  ```
  - Usa SQLite (`/app/sqlite-data/db.sqlite3`) e mídia local (`/app/media/produtos`).

- **Modo Cloud Local** (dentro do Docker, `.env` mínima):
  ```
  USE_CLOUD_BACKENDS=True
  CLOUD_SQL_CONNECTION_NAME=graphic-charter-467905-m5:southamerica-east1:ezgestor-db
  DATABASE_URL=mysql://root:<URLENCODED_PASSWORD>@cloudsql-proxy:3306/ezgestor?charset=utf8mb4
  GS_BUCKET_NAME=<seu-bucket>
  ```
  - Inicia sidecar `cloudsql-proxy`; uploads vão para GCS.

#### Notas de Rollout
- Rebuild da imagem: `docker compose build` (inclui novas deps).
- Sem migrações de DB necessárias; `ImageField` existente (ex.: em `estoque/models.py`) permanece válido.
- Monitore: Após deploy, verifique se uploads persistem em restarts do Cloud Run (GCS é durável).