### PR TITLE
fix: Fix profile picture image handling in the mobile app

### DIFF
--- a/mobile/app/(tabs)/settings/company-profile.tsx
+++ b/mobile/app/(tabs)/settings/company-profile.tsx
@@ -7,13 +7,14 @@ import {
   TextInput,
   Image,
   ActivityIndicator,
+  Platform,
 } from 'react-native';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { useRouter } from 'expo-router';
 import * as ImagePicker from 'expo-image-picker';
 import { useAuth } from '@/context/AuthContext';
 import { useTheme } from '@/context/ThemeContext';
-import api from '@/services/api';
+import api from '@/utils/api';
 import {
   aplicarMascaraCep,
   aplicarMascaraCnpj,
@@ -39,8 +40,28 @@ interface CompanyData {
   logotipo: string;
 }
 
+type AllowedExtensions =
+  | 'bmp' | 'dib' | 'gif' | 'jfif' | 'jpe' | 'jpg' | 'jpeg'
+  | 'pbm' | 'pgm' | 'ppm' | 'pnm' | 'pfm' | 'png' | 'apng'
+  | 'avif' | 'avifs' | 'blp' | 'bufr' | 'cur' | 'pcx' | 'dcx'
+  | 'dds' | 'ps' | 'eps' | 'fit' | 'fits' | 'fli' | 'flc' | 'ftc'
+  | 'ftu' | 'gbr' | 'grib' | 'h5' | 'hdf' | 'jp2' | 'j2k' | 'jpc'
+  | 'jpf' | 'jpx' | 'j2c' | 'icns' | 'ico' | 'im' | 'iim' | 'mpg'
+  | 'mpeg' | 'tif' | 'tiff' | 'mpo' | 'msp' | 'palm' | 'pcd'
+  | 'pdf' | 'pxr' | 'psd' | 'qoi' | 'bw' | 'rgb' | 'rgba' | 'sgi'
+  | 'ras' | 'tga' | 'icb' | 'vda' | 'vst' | 'webp' | 'wmf' | 'emf'
+  | 'xbm' | 'xpm';
+
+interface SelectedLogo {
+  uri: string;
+  name: string;
+  type: string;
+  extension: AllowedExtensions;
+  file?: any; // File/Blob when running on web
+}
+
 interface ICompanyForm extends Omit<CompanyData, 'logotipo' | 'id'> {
-  logotipo: { uri: string; name: string; type: string } | null;
+  logotipo: SelectedLogo | null;
 }
 
 export default function CompanyProfileScreen() {
@@ -158,15 +179,50 @@ export default function CompanyProfileScreen() {
     if (!result.canceled) {
       const file = result.assets[0];
       const filename = file.uri.split('/').pop() || 'photo.jpg';
-      const match = /\.(\w+)$/.exec(filename);
-      const type = match ? `image/${match[1]}` : `image/jpeg`;
+      const extensionMatch = filename.toLowerCase().match(/\.([a-z0-9]+)$/);
+      const extension = (extensionMatch ? extensionMatch[1] : 'jpg') as AllowedExtensions;
+      const allowedExtensions = new Set<AllowedExtensions>([
+        'bmp','dib','gif','jfif','jpe','jpg','jpeg','pbm','pgm','ppm','pnm','pfm','png','apng','avif','avifs','blp','bufr','cur','pcx','dcx','dds','ps','eps','fit','fits','fli','flc','ftc','ftu','gbr','grib','h5','hdf','jp2','j2k','jpc','jpf','jpx','j2c','icns','ico','im','iim','mpg','mpeg','tif','tiff','mpo','msp','palm','pcd','pdf','pxr','psd','qoi','bw','rgb','rgba','sgi','ras','tga','icb','vda','vst','webp','wmf','emf','xbm','xpm',
+      ]);
+      const isAllowed = allowedExtensions.has(extension);
+      if (!isAllowed) {
+        setToast({ message: `Extensão ${extension} não permitida.`, type: 'error' });
+        return;
+      }
+      const filenameWithExtension = extensionMatch ? filename : `${filename}.${extension}`;
+      const mimeType = extension === 'jpg' || extension === 'jpeg' || extension === 'jpe' ? 'image/jpeg'
+        : extension === 'png' || extension === 'apng' ? 'image/png'
+        : file.mimeType
+        || formData.logotipo?.type
+        || `image/${extension}`;
 
-      console.log('Imagem selecionada:', { uri: file.uri, name: filename, type });
+      // Expo returns file size in bytes when available
+  const fileSize = typeof file.fileSize === 'number' ? file.fileSize : undefined;
+      const maxBytes = 2 * 1024 * 1024; // 2MB limit to match web client
+      if (fileSize && fileSize > maxBytes) {
+        setToast({ message: 'O arquivo deve ter no máximo 2MB.', type: 'error' });
+        return;
+      }
+
+      if (!mimeType.startsWith('image/')) {
+        setToast({ message: 'Apenas arquivos de imagem são permitidos.', type: 'error' });
+        return;
+      }
+
+  const uploadUri = file.uri;
+
+  console.log('Imagem selecionada:', { uri: uploadUri, name: filenameWithExtension, mimeType, size: fileSize });
 
       setLogoPreview(file.uri);
       setFormData(prev => ({
         ...prev,
-        logotipo: { uri: file.uri, name: filename, type },
+        logotipo: {
+          uri: uploadUri,
+          name: filenameWithExtension,
+          type: mimeType,
+          extension,
+          file: (file as any).file ?? undefined,
+        },
       }));
     }
   };
@@ -197,15 +253,35 @@ export default function CompanyProfileScreen() {
     
     // Add image file if present
     if (formData.logotipo) {
-      // React Native FormData requires this specific format for file uploads
-      const fileData: any = {
-        uri: formData.logotipo.uri,
-        name: formData.logotipo.name,
-        type: formData.logotipo.type,
-      };
-      
-      console.log('Enviando arquivo:', fileData);
-      dataToSubmit.append('logotipo', fileData);
+      if (Platform.OS === 'web') {
+        try {
+          const candidate = formData.logotipo.file;
+          const isFile = typeof File !== 'undefined' && candidate instanceof File;
+          const isBlob = typeof Blob !== 'undefined' && candidate instanceof Blob;
+
+          if (candidate && (isFile || isBlob)) {
+            dataToSubmit.append('logotipo', candidate, formData.logotipo.name);
+          } else {
+            const response = await fetch(formData.logotipo.uri);
+            const blob = await response.blob();
+            dataToSubmit.append('logotipo', blob, formData.logotipo.name);
+          }
+        } catch (blobError) {
+          console.error('Falha ao converter a imagem para upload:', blobError);
+          setToast({ message: 'Não foi possível preparar a imagem para upload.', type: 'error' });
+          setIsLoading(false);
+          return;
+        }
+      } else {
+        const fileData: any = {
+          uri: formData.logotipo.uri,
+          name: formData.logotipo.name,
+          type: formData.logotipo.type,
+        };
+
+        console.log('Enviando arquivo:', fileData);
+        dataToSubmit.append('logotipo', fileData, fileData.name);
+      }
     }
 
     try {

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -19,6 +19,7 @@
         "expo": "^54.0.21",
         "expo-blur": "~15.0.7",
         "expo-constants": "~18.0.8",
+        "expo-file-system": "~17.0.1",
         "expo-font": "~14.0.8",
         "expo-haptics": "~15.0.7",
         "expo-image": "~3.0.8",
@@ -6448,13 +6449,12 @@
       }
     },
     "node_modules/expo-file-system": {
-      "version": "19.0.17",
-      "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-19.0.17.tgz",
-      "integrity": "sha512-WwaS01SUFrxBnExn87pg0sCTJjZpf2KAOzfImG0o8yhkU7fbYpihpl/oocXBEsNbj58a8hVt1Y4CVV5c1tzu/g==",
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-17.0.1.tgz",
+      "integrity": "sha512-dYpnZJqTGj6HCYJyXAgpFkQWsiCH3HY1ek2cFZVHFoEc5tLz9gmdEgTF6nFHurvmvfmXqxi7a5CXyVm0aFYJBw==",
       "license": "MIT",
       "peerDependencies": {
-        "expo": "*",
-        "react-native": "*"
+        "expo": "*"
       }
     },
     "node_modules/expo-font": {
@@ -7097,6 +7097,16 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "license": "MIT"
+    },
+    "node_modules/expo/node_modules/expo-file-system": {
+      "version": "19.0.17",
+      "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-19.0.17.tgz",
+      "integrity": "sha512-WwaS01SUFrxBnExn87pg0sCTJjZpf2KAOzfImG0o8yhkU7fbYpihpl/oocXBEsNbj58a8hVt1Y4CVV5c1tzu/g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react-native": "*"
+      }
     },
     "node_modules/expo/node_modules/minimatch": {
       "version": "9.0.5",

--- a/mobile/services/StockService.ts
+++ b/mobile/services/StockService.ts
@@ -54,7 +54,7 @@ export const createProduct = async (productData: Product): Promise<Product> => {
         formData.append('imagem', blob, fileName);
       } else {
         // On native, append RN-style file descriptor
-        formData.append('imagem', { uri: productData.imagem.uri, name: fileName, type: mimeType } as any);
+  formData.append('imagem', { uri: productData.imagem.uri, name: fileName, type: mimeType } as any, fileName);
       }
     }
 
@@ -84,7 +84,7 @@ export const updateProduct = async (productId: number, productData: Product): Pr
       const blob = await resp.blob();
       formData.append('imagem', blob, fileName);
     } else {
-      formData.append('imagem', { uri: productData.imagem.uri, name: fileName, type: mimeType } as any);
+  formData.append('imagem', { uri: productData.imagem.uri, name: fileName, type: mimeType } as any, fileName);
     }
   }
 


### PR DESCRIPTION
This pull request introduces significant improvements to image upload handling for both company profile and product management, with a focus on better file validation, platform compatibility, and more robust multipart form data processing. The changes ensure that only allowed image types and sizes are accepted, improve error handling, and standardize how files are appended to `FormData` across web and native platforms.

**Image upload validation and handling improvements:**

* Added an `AllowedExtensions` type and a `SelectedLogo` interface to strictly validate image file extensions and structure the selected logo data in `company-profile.tsx`.
* Enhanced the image selection logic to check for allowed extensions, file size (max 2MB), and MIME type, providing user feedback for invalid uploads.
* Improved platform-specific handling for uploading images: on web, files are appended as `Blob` or `File`; on native, the React Native file descriptor format is used. Includes error handling for failed conversions.

**FormData and multipart request processing:**

* Updated the API request interceptor to detect FormData payloads more reliably and prevent serialization of multipart data, ensuring headers are correctly set and requests are not transformed unnecessarily.
* Standardized appending files to FormData for product creation and update in `StockService.ts`, ensuring file names are consistently included. [[1]](diffhunk://#diff-babb249aec2ad810bed06ba286d20b1e6da37ec4439dfa3c718d81bdd226a5adL57-R57) [[2]](diffhunk://#diff-babb249aec2ad810bed06ba286d20b1e6da37ec4439dfa3c718d81bdd226a5adL87-R87)

**Dependency and import updates:**

* Changed the import path for the API module from `@/services/api` to `@/utils/api` in `company-profile.tsx` for consistency.
* Updated dependencies in `package-lock.json` to include `expo-file-system`, and resolved versioning for compatibility. [[1]](diffhunk://#diff-d5fe0185c2fabe5669a3fc3f72d11da87ac666837c125f878a81a234aedbc38bR22) [[2]](diffhunk://#diff-d5fe0185c2fabe5669a3fc3f72d11da87ac666837c125f878a81a234aedbc38bL6451-R6457) [[3]](diffhunk://#diff-d5fe0185c2fabe5669a3fc3f72d11da87ac666837c125f878a81a234aedbc38bR7101-R7110)